### PR TITLE
feat: 서버 갑자기 종료 될 시 예외 처리/#54

### DIFF
--- a/src/channel/channel.module.ts
+++ b/src/channel/channel.module.ts
@@ -17,6 +17,6 @@ import { AuthModule } from "src/auth/auth.module";
   ],
   controllers: [ChannelController],
   providers: [UserService, ChannelGateWay, ChannelsService, Redis],
-  exports: [ChannelsService, Redis],
+  exports: [ChannelsService, Redis, ChannelGateWay],
 })
 export class ChannelModule {}

--- a/src/channel/channel.service.ts
+++ b/src/channel/channel.service.ts
@@ -256,7 +256,7 @@ export class ChannelsService {
     const channelUserInfo = await this.channelUserRepository.find();
     for (let i = 0; i < channelUserInfo.length; i++) {
       this.channelUserRepository.update(
-        { id: channelUserInfo[i].id },
+        { id: channelUserInfo[i].id, deleted_at: IsNull() },
         { deleted_at: new Date() },
       );
     }

--- a/src/game/game.module.ts
+++ b/src/game/game.module.ts
@@ -12,6 +12,8 @@ import { UserService } from "src/user/user.service";
 import { GameChannel } from "./entity/game.channel.entity";
 import { GameGateWay } from "./game.gateway";
 import { GameChannelService } from "./game.channel.service";
+import { UserModule } from "src/user/user.module";
+import { ChannelsService } from "src/channel/channel.service";
 
 @Module({
   imports: [

--- a/src/game/game.player.service.ts
+++ b/src/game/game.player.service.ts
@@ -1,6 +1,12 @@
-import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
+import {
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  forwardRef,
+} from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
-import { Repository } from "typeorm";
+import { In, Repository } from "typeorm";
 import { GamePlayer } from "./entity/game.player.entity";
 import { UserService } from "src/user/user.service";
 import { gameRecordDto, gameStatsDto } from "./dto/game.dto";
@@ -15,6 +21,7 @@ export class GamePlayerService {
     private gameRepository: Repository<Game>,
     @InjectRepository(GamePlayer)
     private gamePlayerRepository: Repository<GamePlayer>,
+    @Inject(forwardRef(() => UserService))
     private userServie: UserService,
   ) {}
 

--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -23,9 +23,7 @@ export class GameService {
     private gameChannelRepository: Repository<Game>,
     @InjectRepository(Game)
     private gameRepository: Repository<Game>,
-    private userService: UserService,
-    private redisClient: Redis,
-  ) { }
+  ) {}
 
   async saveGame(channelId: number) {
     try {
@@ -86,6 +84,20 @@ export class GameService {
           },
         );
       }
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  async deleteAllGame() {
+    try {
+      await this.gameRepository.update(
+        { ended_at: IsNull() },
+        {
+          ended_at: new Date(),
+        },
+      );
     } catch (error) {
       this.logger.error(error);
       throw error;

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -358,7 +358,7 @@ export class UserController {
     );
     try {
       const UserInfo = await this.userService.findUserByNickname(nickname);
-      console.log(UserInfo);
+      //console.log(UserInfo);
       const UserGameInfo = await this.gamePlayerService.findGamesByUserId(
         UserInfo.id,
       );

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -20,6 +20,13 @@ import { GameGateWay } from "src/game/game.gateway";
 import { GameChannel } from "src/game/entity/game.channel.entity";
 import { GamePlayer } from "src/game/entity/game.player.entity";
 import { Game } from "src/game/entity/game.entity";
+import { ChannelModule } from "src/channel/channel.module";
+import { Channels } from "src/channel/entity/channels.entity";
+import { ChannelUser } from "src/channel/entity/channel.user.entity";
+import { GameChannelService } from "src/game/game.channel.service";
+import { ChannelsService } from "src/channel/channel.service";
+import { GameService } from "src/game/game.service";
+import { GamePlayerService } from "src/game/game.player.service";
 //import { JwtStrategy } from '../auth/strategy/jwt.strategy';
 
 const jwtConfig = config.get("jwt");
@@ -34,9 +41,9 @@ const jwtConfig = config.get("jwt");
       GameChannel,
       GamePlayer,
       Game,
+      Channels,
+      ChannelUser,
     ]),
-    GameModule,
-    Redis,
   ],
   controllers: [UserController],
   providers: [
@@ -49,6 +56,11 @@ const jwtConfig = config.get("jwt");
     Game,
     GameChannel,
     GamePlayer,
+    UserGateway,
+    GamePlayerService,
+    GameChannelService,
+    GameService,
+    ChannelsService,
   ],
   exports: [UserService, UserGateway],
 })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -86,6 +86,15 @@ export class UserService {
     return user;
   }
 
+  async reconnectUser() {
+    const users = await this.userRepository.update(
+      {
+        status: UserStatus.ONLINE,
+      },
+      { status: UserStatus.OFFLINE },
+    );
+  }
+
   //  async updateAvatar(
   //    nickname: string,
   //    profileUrl: string,


### PR DESCRIPTION
- feat: user, on/offline 기능 구현 했습니다 (테스트 필요)

- 서버 갑자기 내려간 경우 처리 했습니다 (user소켓 첫 연결시 현재 소켓에 연결된 인원수가 1인 경우를 기준)
1. 모든 channelsUser의 deleted_at 이 null인 경우 deleted_at 모두 현재 시각으로 초기화
2. 모든 channels의 cur_user 0으로 초기화
3. 모든 gameChannel의 deleted_at이 null인경우 redis "GM|*" 삭제 및 deleted_at 현재 시간으로 초기화
4. 모든 game 중 진행중인 게임 (== ended_at이 null인 경우) ended_at 현재시간으로 초기화 즉, 게임 통계에 담지 않는 게임이 되버림