### PR TITLE
fix: channel, 최소인원 0명에서 2명으로 변경

### DIFF
--- a/src/channel/channel.service.ts
+++ b/src/channel/channel.service.ts
@@ -57,14 +57,14 @@ export class ChannelsService {
           HttpStatus.BAD_REQUEST,
         );
       } else if (
-        chatChannelListDto.maxUser < 0 ||
+        chatChannelListDto.maxUser < 2 ||
         chatChannelListDto.maxUser > 50
       ) {
         // 최대 인원 수 논의 필요
         throw new HttpException(
           {
             status: HttpStatus.BAD_REQUEST,
-            error: "최대 인원은 0명 이상 50명 이하여야 합니다.",
+            error: "최대 인원은 2명 이상 50명 이하여야 합니다.",
           },
           HttpStatus.BAD_REQUEST,
         );


### PR DESCRIPTION
refactor
- 게임 공, 패들 위치 계산 시 사용하던 변수들 전역에서 지역 변수로 변경 후 테스트 완료

feat
- 게임채널 안에서 kick,ban,mute 구현 (추후 기능 제거될 가능성도 있음)

fix
- 소켓 연결인원에 따른 방 리셋 로직 비동기 처리
- 최소인원 최소0명 최대50명에서 최소2명 최대50으로 변경